### PR TITLE
Inverse transform data

### DIFF
--- a/src/interfaces/base_handler.py
+++ b/src/interfaces/base_handler.py
@@ -119,6 +119,16 @@ class BaseHandler(torch.utils.data.Dataset):
         y = y_fit.T  # return the data to the original shape
         return y
 
+    def get_y_scaler(self) -> Any:
+        """
+        Returns the y_scaler object.
+
+        Returns:
+        - Any
+            The y_scaler object.
+        """
+        return self.y_scaler
+
     @abstractmethod
     def __getitem__(self, idx: int) -> Tuple[torch.Tensor, torch.Tensor]:
         raise NotImplementedError

--- a/src/test.py
+++ b/src/test.py
@@ -152,8 +152,21 @@ if __name__ == "__main__":
         is_train=False,
         return_fig=True,
     )
-    wandb.log({"Plots/Test": fig})
+    wandb.log({"Plots/Test_Unscaled": fig})
 
+    # Plot results for scaled outputs and targets
+    outputs = pd.read_csv(predictions_dir / "scaled_outputs.csv")
+    targets = pd.read_csv(predictions_dir / "scaled_targets.csv")
+
+    fig = visualize_outputs_and_targets(
+        targets=targets,
+        outputs=outputs,
+        plots_dir=plots_dir,
+        file_name="scaled_test_outputs_and_targets.png",
+        is_train=False,
+        return_fig=True,
+    )
+    wandb.log({"Plots/Test_Scaled": fig})
     logger.info(f"Outputs and targets visualization saved to {predictions_dir}")
 
     if config.testing.run_on_train_data:
@@ -226,6 +239,21 @@ if __name__ == "__main__":
             is_train=True,
             return_fig=True,
         )
-        wandb.log({"Plots/Train": fig})
+        wandb.log({"Plots/Train_Unscaled": fig})
+
+        # Plot results for scaled outputs and targets
+        outputs = pd.read_csv(predictions_dir / "scaled_outputs.csv")
+        targets = pd.read_csv(predictions_dir / "scaled_targets.csv")
+
+        fig = visualize_outputs_and_targets(
+            targets=targets,
+            outputs=outputs,
+            plots_dir=plots_dir,
+            file_name="scaled_train_outputs_and_targets.png",
+            is_train=False,
+            return_fig=True,
+        )
+        wandb.log({"Plots/Train_Scaled": fig})
+
         logger.info(f"Outputs and targets visualization saved to {predictions_dir}")
         wandb.finish()

--- a/src/test.py
+++ b/src/test.py
@@ -14,7 +14,6 @@ from utils import (
     load_data_handler,
 )
 from visualize.visualize_dataset import visualize_outputs_and_targets
-from sklearn.preprocessing import StandardScaler
 import wandb
 
 
@@ -48,7 +47,6 @@ if __name__ == "__main__":
         config.data,
         results_dir=results_dir_path,
         is_train=False,
-        y_scaler=StandardScaler(),
         use_saved_scaler=True,
     )
 
@@ -109,6 +107,9 @@ if __name__ == "__main__":
     model.to(DEVICE)
     start_testing_time = time()
 
+    # Get the y_scaler for the test dataset
+    y_scaler = test_dataset.get_y_scaler()
+
     test_loss, metrics_dict = test_model(
         model=model,
         test_loader=test_loader,
@@ -117,10 +118,11 @@ if __name__ == "__main__":
         tracker=metrics_tracker,
         save_outputs_and_targets=True,
         save_dir=predictions_dir,
+        y_scaler=y_scaler,
     )
 
-    outputs = pd.read_csv(predictions_dir / "outputs.csv")
-    targets = pd.read_csv(predictions_dir / "targets.csv")
+    outputs = pd.read_csv(predictions_dir / "unscaled_outputs.csv")
+    targets = pd.read_csv(predictions_dir / "unscaled_targets.csv")
 
     # Log raw values as a W&B Table
     for channel in range(outputs.shape[1]):
@@ -163,7 +165,6 @@ if __name__ == "__main__":
             config.data,
             results_dir=results_dir_path,
             is_train=True,
-            y_scaler=StandardScaler(),
             use_saved_scaler=True,
         )
 
@@ -193,10 +194,11 @@ if __name__ == "__main__":
             tracker=metrics_tracker,
             save_outputs_and_targets=True,
             save_dir=predictions_dir,
+            y_scaler=y_scaler,
         )
 
-        outputs = pd.read_csv(predictions_dir / "outputs.csv")
-        targets = pd.read_csv(predictions_dir / "targets.csv")
+        outputs = pd.read_csv(predictions_dir / "unscaled_outputs.csv")
+        targets = pd.read_csv(predictions_dir / "unscaled_targets.csv")
 
         # Log raw values as a W&B Table
         for channel in range(outputs.shape[1]):

--- a/src/test.py
+++ b/src/test.py
@@ -136,9 +136,6 @@ if __name__ == "__main__":
 
     # Create a DataFrame from the metrics dictionary
     df_results = pd.DataFrame(metrics_dict)
-    logger.info(
-        "Results {}".format(df_results.to_string().replace("\n", "\n\t\t\t\t\t"))
-    )
 
     wandb.log({"MSE_TEST": test_loss})
 
@@ -148,9 +145,10 @@ if __name__ == "__main__":
 
     # Plot outputs and targets
     fig = visualize_outputs_and_targets(
-        predictions_dir,
-        plots_dir,
-        file_name="test_outputs_and_targets.png",
+        targets=targets,
+        outputs=outputs,
+        plots_dir=plots_dir,
+        file_name="unscaled_test_outputs_and_targets.png",
         is_train=False,
         return_fig=True,
     )
@@ -212,9 +210,6 @@ if __name__ == "__main__":
 
         # Create a DataFrame from the metrics dictionary
         df_results = pd.DataFrame(metrics_dict)
-        logger.info(
-            "Results {}".format(df_results.to_string().replace("\n", "\n\t\t\t\t\t"))
-        )
 
         wandb.log({"MSE_TRAIN": test_loss})
         # Save results to a csv file
@@ -222,11 +217,12 @@ if __name__ == "__main__":
         logger.info(
             f"Results saved to {results_dir_path / 'test_traindata_results.csv'}"
         )
-        # Plot outputs and targets
+        # Plot unscaled outputs and targets
         fig = visualize_outputs_and_targets(
-            predictions_dir,
-            plots_dir,
-            file_name="train_outputs_and_targets.png",
+            targets=targets,
+            outputs=outputs,
+            plots_dir=plots_dir,
+            file_name="unscaled_train_outputs_and_targets.png",
             is_train=True,
             return_fig=True,
         )

--- a/src/test.py
+++ b/src/test.py
@@ -105,11 +105,11 @@ if __name__ == "__main__":
     # Test the model
     logger.info(f"Testing on {DEVICE} using device: {DEVICE_NAME}")
     model.to(DEVICE)
-    start_testing_time = time()
 
     # Get the y_scaler for the test dataset
     y_scaler = test_dataset.get_y_scaler()
 
+    start_testing_time = time()
     test_loss, metrics_dict = test_model(
         model=model,
         test_loader=test_loader,
@@ -120,6 +120,9 @@ if __name__ == "__main__":
         save_dir=predictions_dir,
         y_scaler=y_scaler,
     )
+    total_time = time() - start_testing_time
+    logger.info(f"Test loss: {test_loss:.4f}")
+    logger.info(f"Total testing time: {total_time:.2f} seconds")
 
     outputs = pd.read_csv(predictions_dir / "unscaled_outputs.csv")
     targets = pd.read_csv(predictions_dir / "unscaled_targets.csv")
@@ -130,15 +133,10 @@ if __name__ == "__main__":
         table = wandb.Table(data=data, columns=["model_output", "target"])
         wandb.log({f"test_predictions/channel_{channel}": table})
 
-    total_time = time() - start_testing_time
-    logger.info(f"Test loss: {test_loss:.4f}")
-    logger.info(f"Total testing time: {total_time:.2f} seconds")
+    wandb.log({"TEST_DATA_METRICS": metrics_dict})
 
     # Create a DataFrame from the metrics dictionary
     df_results = pd.DataFrame(metrics_dict)
-
-    wandb.log({"MSE_TEST": test_loss})
-
     # Save results to a csv file
     df_results.to_csv(results_dir_path / "test_results.csv", index=False)
     logger.info(f"Results saved to {results_dir_path / 'test_results.csv'}")
@@ -167,7 +165,7 @@ if __name__ == "__main__":
         return_fig=True,
     )
     wandb.log({"Plots/Test_Scaled": fig})
-    logger.info(f"Outputs and targets visualization saved to {predictions_dir}")
+    logger.info(f"Outputs and targets visualizations saved to {predictions_dir}")
 
     if config.testing.run_on_train_data:
         logger.info("Testing on the training data...")
@@ -207,6 +205,9 @@ if __name__ == "__main__":
             save_dir=predictions_dir,
             y_scaler=y_scaler,
         )
+        total_time = time() - start_testing_time
+        logger.info(f"Test loss: {test_loss:.4f}")
+        logger.info(f"Total testing time: {total_time:.2f} seconds")
 
         outputs = pd.read_csv(predictions_dir / "unscaled_outputs.csv")
         targets = pd.read_csv(predictions_dir / "unscaled_targets.csv")
@@ -217,14 +218,10 @@ if __name__ == "__main__":
             table = wandb.Table(data=data, columns=["model_output", "target"])
             wandb.log({f"train_predictions/channel_{channel}": table})
 
-        total_time = time() - start_testing_time
-        logger.info(f"Test loss: {test_loss:.4f}")
-        logger.info(f"Total testing time: {total_time:.2f} seconds")
+        wandb.log({"TRAIN_DATA_METRICS": metrics_dict})
 
         # Create a DataFrame from the metrics dictionary
         df_results = pd.DataFrame(metrics_dict)
-
-        wandb.log({"MSE_TRAIN": test_loss})
         # Save results to a csv file
         df_results.to_csv(results_dir_path / "test_traindata_results.csv", index=False)
         logger.info(
@@ -255,5 +252,5 @@ if __name__ == "__main__":
         )
         wandb.log({"Plots/Train_Scaled": fig})
 
-        logger.info(f"Outputs and targets visualization saved to {predictions_dir}")
+        logger.info(f"Outputs and targets visualizations saved to {predictions_dir}")
         wandb.finish()

--- a/src/utils/training_utils.py
+++ b/src/utils/training_utils.py
@@ -137,12 +137,14 @@ def test_model(
             )
 
         if save_outputs_and_targets:
+            # Save scaled outputs and targets
+            outputs_df.to_csv(save_dir / "scaled_outputs.csv", index=False)
+            targets_df.to_csv(save_dir / "scaled_targets.csv", index=False)
             # Rescale the outputs and targets if a scaler is provided
             if y_scaler is not None:
                 outputs_df = pd.DataFrame(y_scaler.inverse_transform(outputs_df))
                 targets_df = pd.DataFrame(y_scaler.inverse_transform(targets_df))
             # Calculate MSE on the unscaled data
-            print(outputs_df.values)
             mse = np.mean((outputs_df.values - targets_df.values) ** 2)
             metrics_dict["MSE_unscaled"] = mse
             metrics_dict["RMSE_unscaled"] = np.sqrt(mse)
@@ -151,7 +153,7 @@ def test_model(
             # Add Pearson correlation by each target channel to metrics_dict
             for i, corr in enumerate(pearson_corr):
                 metrics_dict[f"pcorr_unscaled_ch_{i}"] = corr
-
+            # Save unscaled outputs and targets
             outputs_df.to_csv(save_dir / "unscaled_outputs.csv", index=False)
             targets_df.to_csv(save_dir / "unscaled_targets.csv", index=False)
 

--- a/src/visualize/visualize_dataset.py
+++ b/src/visualize/visualize_dataset.py
@@ -41,24 +41,14 @@ def visualize_target(
 
 
 def visualize_outputs_and_targets(
-    predictions_dir: Path,
+    targets: pd.DataFrame,
+    outputs: pd.DataFrame,
     plots_dir: Path,
     file_name: str = "outputs_and_targets.png",
     is_train: bool = False,
     return_fig: bool = False,
 ) -> plt.Figure | None:
-    """
-    Visualizes the model outputs and targets by plotting them on separate channels.
 
-    Args:
-        predictions_dir (Path): The directory containing the predictions.
-
-    Returns:
-        None
-    """
-
-    targets = pd.read_csv(predictions_dir / "unscaled_targets.csv", header=0)
-    outputs = pd.read_csv(predictions_dir / "unscaled_outputs.csv", header=0)
     n_channels: int = targets.shape[-1]
     fig, _ = plt.subplots(
         ncols=1,

--- a/src/visualize/visualize_dataset.py
+++ b/src/visualize/visualize_dataset.py
@@ -57,8 +57,8 @@ def visualize_outputs_and_targets(
         None
     """
 
-    targets = pd.read_csv(predictions_dir / "targets.csv", header=0)
-    outputs = pd.read_csv(predictions_dir / "outputs.csv", header=0)
+    targets = pd.read_csv(predictions_dir / "unscaled_targets.csv", header=0)
+    outputs = pd.read_csv(predictions_dir / "unscaled_outputs.csv", header=0)
     n_channels: int = targets.shape[-1]
     fig, _ = plt.subplots(
         ncols=1,

--- a/src/visualize/visualize_dataset.py
+++ b/src/visualize/visualize_dataset.py
@@ -90,7 +90,7 @@ if __name__ == "__main__":
 
     path = Path("../results/my_training/predictions")
 
-    visualize_outputs_and_targets(path, path)
+    # visualize_outputs_and_targets(path, path)
 
     y_scaler = MinMaxScaler()
     with open("../config.yaml", "r") as stream:


### PR DESCRIPTION
Unscaled data refers to data inverse-transformed by the scaler.

New features:
- saving csv with unscaled outputs and targets
- plotting unscaled outputs and targets
- calculating Pearson correlation of outputs and targets by channel
- calculating RMSE for unscaled outputs and targets
- logging `metrics_dict` to wandb